### PR TITLE
raphael: Disable SDM Scalar

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -553,3 +553,6 @@ PRODUCT_COPY_FILES += \
 # Enable zygote critical window.
 PRODUCT_PROPERTY_OVERRIDES += \
     zygote.critical_window.minute=10
+    
+# Disable SDM Scalar  
+PRODUCT_PROPERTY_OVERRIDES += vendor.display.disable_scaler=1


### PR DESCRIPTION
It will cause "ScalarConfig: :GetPipeScaleSettingsInfo: lib_scale_get_pipe_settings failed: status = 2"

solution found from https://github.com/PixelExperience-Devices/device_motorola_sdm660-common/commit/d756b542acc174410724efc286eb65775e32a695